### PR TITLE
Added a better error handling when it fails to decode a file

### DIFF
--- a/lib/failed_to_decode_image_file_exception.dart
+++ b/lib/failed_to_decode_image_file_exception.dart
@@ -1,0 +1,9 @@
+class FailedToDecodeImageFileException implements Exception {
+  final String message;
+  final String? details;
+
+  FailedToDecodeImageFileException({
+    required this.message,
+    this.details,
+  });
+}

--- a/lib/fc_native_image_resize.dart
+++ b/lib/fc_native_image_resize.dart
@@ -1,4 +1,5 @@
 import 'fc_native_image_resize_platform_interface.dart';
+export 'failed_to_decode_image_file_exception.dart';
 
 class FcNativeImageResize {
   /// Resizes the [srcFile] image with the given options and saves the results

--- a/lib/fc_native_image_resize_method_channel.dart
+++ b/lib/fc_native_image_resize_method_channel.dart
@@ -1,3 +1,4 @@
+import 'package:fc_native_image_resize/failed_to_decode_image_file_exception.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 
@@ -8,6 +9,8 @@ class MethodChannelFcNativeImageResize extends FcNativeImageResizePlatform {
   /// The method channel used to interact with the native platform.
   @visibleForTesting
   final methodChannel = const MethodChannel('fc_native_image_resize');
+  final pluginError = 'PluginError';
+  static const String failedToDecodeImageFile = 'FailedToDecodeImageFile';
 
   @override
   Future<void> resizeFile(
@@ -19,15 +22,25 @@ class MethodChannelFcNativeImageResize extends FcNativeImageResizePlatform {
       required String format,
       bool? srcFileUri,
       int? quality}) async {
-    await methodChannel.invokeMethod<void>('resizeFile', {
-      'srcFile': srcFile,
-      'destFile': destFile,
-      'width': width,
-      'height': height,
-      'keepAspectRatio': keepAspectRatio,
-      'type': format,
-      'srcFileUri': srcFileUri,
-      'quality': quality,
-    });
+    try {
+      await methodChannel.invokeMethod<void>('resizeFile', {
+        'srcFile': srcFile,
+        'destFile': destFile,
+        'width': width,
+        'height': height,
+        'keepAspectRatio': keepAspectRatio,
+        'type': format,
+        'srcFileUri': srcFileUri,
+        'quality': quality,
+      });
+    } on PlatformException catch (e) {
+      switch(e.code) {
+        case failedToDecodeImageFile : throw FailedToDecodeImageFileException(
+          message: e.message!,
+          details: e.details,
+        );
+        default: rethrow;
+      }
+    }
   }
 }


### PR DESCRIPTION
We encountered an issue in our app that sometimes a user might want to pick an image that is not well formatted.
The issue is that the part where the image is being decoded isn't well handled and the plugin only returns PlatformException.
Since we want to only push a better code quality, I added an error handling for that specific part.

We sincerely would like to see this update on pub.dev ASAP